### PR TITLE
Character Constant

### DIFF
--- a/Source Files/Record.cpp
+++ b/Source Files/Record.cpp
@@ -32,7 +32,7 @@ bool doubleCompare(const double& x, const double& y, const char& c){
     if(c == '>'){
         return (x > y && absolute(x-y) >= epsilon);
     }
-    if(c == '=='){
+    if(c == '='){
         return (absolute(x-y) < epsilon);
     }
     else throw runtime_error("Invalid units specified for doubleCompare().");


### PR DESCRIPTION
Forget about the return types, I found that the error only occurred when
I didn't compile all the files together. The character constant warning
was persistent, though. You can only use one character when it's being
contained in single inverted commas.
